### PR TITLE
Fix OAuth2 frontend redirect paths

### DIFF
--- a/src/main/java/bflow/auth/security/OAuth2FailureHandler.java
+++ b/src/main/java/bflow/auth/security/OAuth2FailureHandler.java
@@ -35,7 +35,7 @@ public final class OAuth2FailureHandler
             final HttpServletResponse response,
             final AuthenticationException exception
     ) throws IOException {
-        String redirectUrl = frontendUrl + "/login?error=oauth2";
+        String redirectUrl = frontendUrl + "/auth/login?error=oauth2";
         response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/bflow/auth/security/OAuth2SuccessHandler.java
+++ b/src/main/java/bflow/auth/security/OAuth2SuccessHandler.java
@@ -101,6 +101,6 @@ public final class OAuth2SuccessHandler
         serviceRefreshToken.create(user.getId(), refreshToken);
 
         jwtService.attachAuthCookies(response, accessToken, refreshToken);
-        response.sendRedirect(frontendUrl + "/app/dashboard");
+        response.sendRedirect(frontendUrl + "app/dashboard");
     }
 }

--- a/src/main/java/bflow/rate_limit/scheduler/RateLimitCleanupTask.java
+++ b/src/main/java/bflow/rate_limit/scheduler/RateLimitCleanupTask.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public final class RateLimitCleanupTask {
+public class RateLimitCleanupTask {
 
     /** Initial delay in minutes for cleanup task. */
     private static final long INITIAL_DELAY_MINUTES = 5;

--- a/src/main/java/bflow/recurring/services/RecurringScheduler.java
+++ b/src/main/java/bflow/recurring/services/RecurringScheduler.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
-public final class RecurringScheduler {
+public class RecurringScheduler {
     /**
      * Service for executing recurring transactions.
      */


### PR DESCRIPTION
## Summary
This PR fixes OAuth2 frontend redirection issues.

### Changes
- Fixed OAuth2 failure redirect to use `/auth/login`.
- Fixed OAuth2 success redirect URL construction to avoid invalid paths.

### Result
OAuth2 authentication now redirects to the correct frontend routes after successful or failed login attempts.